### PR TITLE
Fix "AWS managed policies for Amazon GuardDuty" titles

### DIFF
--- a/doc_source/security-iam-awsmanpol.md
+++ b/doc_source/security-iam-awsmanpol.md
@@ -8,7 +8,7 @@ Additionally, AWS supports managed policies for job functions that span multiple
 
 ## <a name="w282aac27c25c11"></a>
 
-## AWS managed policy: AmazonGuardDutyFullAccess<a name="security-iam-awsmanpol-AWSServiceRoleForAmazonGuardDuty"></a>
+## AWS managed policy: AmazonGuardDutyFullAccess<a name="security-iam-awsmanpol-AmazonGuardDutyFullAccess"></a>
 
 You can attach the `AmazonGuardDutyFullAccess` policy to your IAM identities\.
 
@@ -63,7 +63,7 @@ This policy includes the following permissions\.
 }
 ```
 
-## AWS managed policy: AmazonGuardDutyFullAccess<a name="security-iam-awsmanpol-AWSServiceRoleForAmazonGuardDuty"></a>
+## AWS managed policy: AmazonGuardDutyReadOnlyAccess<a name="security-iam-awsmanpol-AmazonGuardDutyReadOnlyAccess"></a>
 
 You can attach the `AmazonGuardDutyReadOnlyAccess` policy to your IAM identities\.
 


### PR DESCRIPTION
*Description of changes:*
- fixed title headings for "AWS managed policies for Amazon GuardDuty" page


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
