### PR TITLE
Corrected command for connecting to tester instance

### DIFF
--- a/doc_source/sample_findings.md
+++ b/doc_source/sample_findings.md
@@ -69,7 +69,7 @@ You can use the following [scripts](https://github.com/awslabs/amazon-guardduty-
            HostName {Local IP Address of RedTeam Instance}
            User ec2-user
            IdentityFile ~/.ssh/{your-ssh-key.pem}
-           ProxyCommand ssh bastion nc %h %p
+           ProxyCommand ssh %h:%p bastion
            ServerAliveInterval 240
    ```
 


### PR DESCRIPTION
*Issue #, if available: 26

*Description of changes: Use of NetCat with ProxyCommand (ProxyCommand ssh bastion nc %h %p) no longer supported with the instances created in the Workshop. To resolve issue, use "-W" switch with OpenSSH (ProxyCommand ssh %h:%p bastion) to create the multi-hop tunnel through the bastion host to the tester instance.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
