### PR TITLE
Update security_iam_id-based-policy-examples.md

### DIFF
--- a/doc_source/security_iam_id-based-policy-examples.md
+++ b/doc_source/security_iam_id-based-policy-examples.md
@@ -51,10 +51,16 @@ To grant permissions required to enable GuardDuty, attach the following policy t
             "Action": [
                 "iam:CreateServiceLinkedRole"
             ],
-            "Resource": "arn:aws:iam::123456789012:role/aws-service-role/guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDuty",
+            "Resource": [
+                "arn:aws:iam::123456789012:role/aws-service-role/guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDuty",
+                "arn:aws:iam::123456789012:role/aws-service-role/malware-protection.guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDutyMalwareProtection"
+            ],
             "Condition": {
                 "StringLike": {
-                    "iam:AWSServiceName": "guardduty.amazonaws.com"
+                    "iam:AWSServiceName": [
+                        "guardduty.amazonaws.com",
+                        "malware-protection.guardduty.amazonaws.com"
+                    ]
                 }
             }
         },
@@ -64,7 +70,17 @@ To grant permissions required to enable GuardDuty, attach the following policy t
                 "iam:PutRolePolicy",
                 "iam:DeleteRolePolicy"
             ],
-            "Resource": "arn:aws:iam::1234567890123:role/aws-service-role/guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDuty"
+            "Resource": [
+                "arn:aws:iam::123456789012:role/aws-service-role/guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDuty",
+                "arn:aws:iam::123456789012:role/aws-service-role/malware-protection.guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDutyMalwareProtection"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetRole"
+            ],
+            "Resource": "arn:aws:iam::123456789012:role/aws-service-role/malware-protection.guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDutyMalwareProtection"
         }
     ]
 }


### PR DESCRIPTION
Update "Permissions required to enable GuardDuty" section to adopt the new Malware Detection feature

*Issue #, if available:*

*Description of changes:*

The rollout of new Malware Protection feature requires users / services to have permission to create and get the Service-linked role **AWSServiceRoleForAmazonGuardDutyMalwareProtection** while enabling GuardDuty.

So we need to update the sample IAM policy to reflect this change. Otherwise, the existing policy is not sufficient to enable GuardDuty.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
